### PR TITLE
Implement CLI initialization logic for AION

### DIFF
--- a/tools/cli/aion-cli.js
+++ b/tools/cli/aion-cli.js
@@ -7,6 +7,7 @@
 const { program } = require('commander');
 const chalk = require('chalk');
 const figlet = require('figlet');
+const AIONInitializer = require('../aion/aion-init');
 
 // Display welcome banner
 console.log(
@@ -28,10 +29,9 @@ program
 program
   .command('init')
   .description('Initialize AION project')
-  .action(() => {
-    console.log(chalk.blue('🚀 Initializing AION project...'));
-    console.log(chalk.gray('This will setup BMAD foundation and AION modules'));
-    // TODO: Implement initialization logic
+  .action(async () => {
+    const initializer = new AIONInitializer();
+    await initializer.init();
   });
 
 program


### PR DESCRIPTION
The logic for the `aion init` command was implemented by connecting the CLI command in `tools/cli/aion-cli.js` to the `AIONInitializer` class in `tools/aion/aion-init.js`. This allows the CLI to properly set up the BMAD foundation and AION modules. The command was tested manually by running `node tools/cli/aion-cli.js init` and confirming that it invokes the initialization process as expected.

---
*PR created automatically by Jules for task [15744799516831869354](https://jules.google.com/task/15744799516831869354) started by @helton-godoy*